### PR TITLE
Adding secret init container to helm chart

### DIFF
--- a/helm/charts/oas-unlock-bot/templates/deployment.yaml
+++ b/helm/charts/oas-unlock-bot/templates/deployment.yaml
@@ -22,6 +22,16 @@ spec:
         app.kubernetes.io/name: {{ include "name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+{{ if .Values.secrets.enabled }}
+      initContainers:
+        - name: init-secrets
+          image: {{ .Values.secrets.image }}
+          imagePullPolicy: Always
+          {{- if .Values.secrets.env }}
+          env:
+{{ toYaml .Values.secrets.env | indent 10 }}
+          {{ end }}     
+{{ end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/helm/charts/oas-unlock-bot/values.yaml
+++ b/helm/charts/oas-unlock-bot/values.yaml
@@ -1,6 +1,8 @@
 # Default values for sc-digital-centre.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+secrets:
+  enabled: false
 
 image:
   repository: nginx

--- a/helmfile/bdmDevContext.sh
+++ b/helmfile/bdmDevContext.sh
@@ -8,4 +8,6 @@ export KEYVAULT_READ_PASSWORD=$(az keyvault secret show --vault-name $KEYVAULT_N
 export K8S_CLUSTER_NAME=ESdCDPSBDMK8SDev-K8S
 export K8S_RG_NAME=ESdCDPSBDMK8SDev
 export BASE_DOMAIN=bdm-dev.dts-stn.com
+export PROJECT=dts-oas-callback-bot
+export BRANCH=main
 az aks get-credentials --name $K8S_CLUSTER_NAME --resource-group $K8S_RG_NAME

--- a/helmfile/overrides/oas-unlock-bot-api.yaml.gotmpl
+++ b/helmfile/overrides/oas-unlock-bot-api.yaml.gotmpl
@@ -22,3 +22,26 @@ healthChecks:
     livenessPath: /
     readinessPath: /
 port: 3978
+secrets:
+   enabled: true 
+   env: 
+    - name: KEYVAULT_READ_USER
+      value: {{ requiredEnv "KEYVAULT_READ_USER" }}
+    - name: KEYVAULT_READ_PASSWORD
+      value: {{ requiredEnv "KEYVAULT_READ_PASSWORD" }}  
+    - name: SUBSCRIPTION_ID
+      value: {{ requiredEnv "SUBSCRIPTION_ID" }}  
+    - name: TENANT_ID
+      value: {{ requiredEnv "TENANT_ID" }}  
+    - name: KEYVAULT_NAME
+      value: {{ requiredEnv "KEYVAULT_NAME" }}  
+    - name: K8S_CLUSTER_NAME
+      value: {{ requiredEnv "K8S_CLUSTER_NAME" }}             
+    - name: K8S_RG_NAME
+      value: {{ requiredEnv "K8S_RG_NAME" }}   
+    - name: SECRET_MOUNT_PATH
+      value: "asdfdsaf"
+    - name: NAMESPACE
+      value: {{ .Release.Namespace }}
+    - name: SECRET_LIST
+      value: "confluence-database-password,confluence-license"      


### PR DESCRIPTION
I added the init secrets container to the helm chart and provided a dummy config in the bot-api overrides. It needs to be configured to reflect the secrets you want to set.